### PR TITLE
PLF-8119 : Add JDK 11 support 

### DIFF
--- a/exo.ws.rest.core/pom.xml
+++ b/exo.ws.rest.core/pom.xml
@@ -67,12 +67,6 @@
       <dependency>
          <groupId>javax.mail</groupId>
          <artifactId>mail</artifactId>
-         <exclusions>
-            <exclusion>
-               <groupId>javax.activation</groupId>
-               <artifactId>activation</artifactId>
-            </exclusion>
-         </exclusions>
       </dependency>
       <dependency>
          <groupId>javax.ws.rs</groupId>


### PR DESCRIPTION
JDK 11 does not bundle javax.activation:activation anymore so it must be included in PLF classpath and therefore not be excluded.